### PR TITLE
Update Comment Configuration

### DIFF
--- a/irule.configuration.json
+++ b/irule.configuration.json
@@ -12,9 +12,7 @@
     },
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#",
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Update irule.configuration.json to have the correct definition for comment syntax in iRules. There are no block comments in iRules, and line comments use '#' rather than '//' to denote comments